### PR TITLE
Missing types for TransitionToLeft and cleanup

### DIFF
--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -11,35 +11,35 @@ import NavSearchBox from './src/components/NavBar/NavSearchBox'
 import TransitionToLeft from './src/components/NavBar/Transition/TransitionToLeft'
 
 import Accordion from './src/components/Accordion'
-import Alert from './src/components/Alert'
 import AvatarView from './src/components/AvatarView'
+import Alert from './src/components/Alert'
 import Button from './src/components/Button'
-import ButtonFluent from './src/components/ButtonFluent'
 import ButtonIcon from './src/components/ButtonIcon'
+import ButtonFluent from './src/components/ButtonFluent'
 import Card from './src/components/Card'
 import Checkbox from './src/components/Checkbox'
-import ColorPickerItem from './src/components/ColorPickerItem'
 import CommandBar from './src/components/CommandBar'
+import ColorPickerItem from './src/components/ColorPickerItem'
 import Dialog from './src/components/Dialog'
 import Gauge from './src/components/Gauge'
 import HeaderFixedContainer from './src/components/HeaderFixedContainer'
 import ImageView from './src/components/ImageView'
 import InputDate from './src/components/InputDate'
+import InputText from './src/components/InputText'
 import InputSearchBar from './src/components/InputSearchBar'
 import InputSearchBox from './src/components/InputSearchBox'
 import InputSearchSuggestion from './src/components/InputSearchSuggestion'
-import InputText from './src/components/InputText'
 import LinkCompound from './src/components/LinkCompound'
 import LinkCompoundFluent from './src/components/LinkCompoundFluent'
-import ListItem from './src/components/ListItem'
 import LoaderBar from './src/components/LoaderBar'
 import LoaderBusy from './src/components/LoaderBusy'
+import ListItem from './src/components/ListItem'
 import MenuBar from './src/components/MenuBar'
 import ProgressBar from './src/components/ProgressBar'
 import ProgressBarIndeterminate from './src/components/ProgressBarIndeterminate'
 import RadioButton from './src/components/RadioButton'
-import SelectBox from './src/components/SelectBox'
 import SliderBar from './src/components/SliderBar'
+import SelectBox from './src/components/SelectBox'
 import StickyHeader from './src/components/StickyHeader'
 import Switch from './src/components/Switch'
 import SwitchDayNight from './src/components/SwitchDayNight'
@@ -52,41 +52,42 @@ export {
     NavBarLinkFluent,
     NavBarLinkUser,
     NavPageContainer,
-    NavPageContainerInner,
     NavPageContainerRight,
+    NavPageContainerInner,
     NavSearchBox,
     TransitionToLeft,
 
     Accordion,
-    Alert,
     AvatarView,
+    Alert,
     Button,
+    ButtonIcon,
     ButtonFluent,
     ButtonIcon,
     Card,
     Checkbox,
-    ColorPickerItem,
     CommandBar,
+    ColorPickerItem,
     Dialog,
     Gauge,
     HeaderFixedContainer,
     ImageView,
     InputDate,
+    InputText,
     InputSearchBar,
     InputSearchBox,
     InputSearchSuggestion,
-    InputText,
     LinkCompound,
     LinkCompoundFluent,
-    ListItem,
     LoaderBar,
     LoaderBusy,
+    ListItem,
     MenuBar,
     ProgressBar,
     ProgressBarIndeterminate,
     RadioButton,
-    SelectBox,
     SliderBar,
+    SelectBox,
     StickyHeader,
     Switch,
     SwitchDayNight,

--- a/src/lib/index.d.ts
+++ b/src/lib/index.d.ts
@@ -1,14 +1,13 @@
-import React from 'react'
-
-import NavBar from './src/components/NavBar/NavBar'
-import NavBarLink from './src/components/NavBar/NavBarLink'
-import NavBarLinkFluent from './src/components/NavBar/NavBarLinkFluent'
-import NavBarLinkUser from './src/components/NavBar/NavBarLinkUser'
-import NavPageContainer from './src/components/NavBar/NavPageContainer'
-import NavPageContainerInner from './src/components/NavBar/NavPageContainerInner'
-import NavPageContainerRight from './src/components/NavBar/NavPageContainerRight'
-import NavSearchBox from './src/components/NavBar/NavSearchBox'
-import TransitionToLeft from './src/components/NavBar/Transition/TransitionToLeft'
+import {
+    NavBar,
+    NavBarLink,
+    NavBarLinkFluent,
+    NavBarLinkUser,
+    NavPageContainer,
+    NavPageContainerRight,
+    NavPageContainerInner,
+    NavSearchBox,
+    TransitionToLeft } from './src/components/NavBar'
 
 import Accordion from './src/components/Accordion'
 import AvatarView from './src/components/AvatarView'
@@ -63,7 +62,6 @@ export {
     Button,
     ButtonIcon,
     ButtonFluent,
-    ButtonIcon,
     Card,
     Checkbox,
     CommandBar,

--- a/src/lib/src/components/NavBar/Transition/TransitionToLeft.d.ts
+++ b/src/lib/src/components/NavBar/Transition/TransitionToLeft.d.ts
@@ -1,0 +1,6 @@
+import React from 'react'
+
+export interface TransitionToLeftProps {}
+declare const TransitionToLeft: React.SFC<TransitionToLeftProps>
+
+export default TransitionToLeft

--- a/src/lib/src/components/NavBar/index.d.ts
+++ b/src/lib/src/components/NavBar/index.d.ts
@@ -1,0 +1,21 @@
+import NavBar from './NavBar'
+import NavBarLink from './NavBarLink'
+import NavBarLinkFluent from './NavBarLinkFluent'
+import NavBarLinkUser from './NavBarLinkUser'
+import NavPageContainer from './NavPageContainer'
+import NavPageContainerRight from './NavPageContainerRight'
+import NavPageContainerInner from './NavPageContainerInner'
+import NavSearchBox from './NavSearchBox'
+import TransitionToLeft from './Transition/TransitionToLeft'
+
+export {
+    NavBar,
+    NavBarLink,
+    NavBarLinkFluent,
+    NavBarLinkUser,
+    NavPageContainer,
+    NavPageContainerRight,
+    NavPageContainerInner,
+    NavSearchBox,
+    TransitionToLeft
+}


### PR DESCRIPTION
## List of changes
- I added type definitions for TransitionToLeft as it was imported in **.\src\lib\index.d.ts** but not actually typed.
- NavBar has an index.js to bring all of the sub-components together, so I added a index.d.ts to follow the same procedure
- I changed the order of the imports and exports in **.\src\lib\index.d.ts** to match the order in index.js
This allows me to just use _compare_ from vscode to see if somthing is missing

### VSCode - Compare: index.js <-> index.d.ts
![image](https://user-images.githubusercontent.com/39999330/123435572-fdeb4b80-d5cd-11eb-85c4-5e7769e58be0.png)

As you can see in the picture the files are almost identical which means we typed everything.
Only util classes / components are not typed and I don't know how to properly handle those.